### PR TITLE
frameworks/base: Fix USB media removed notification to be dismissable

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/usb/StorageNotification.java
+++ b/packages/SystemUI/src/com/android/systemui/usb/StorageNotification.java
@@ -228,7 +228,7 @@ public class StorageNotification extends SystemUI {
                     com.android.internal.R.string.ext_media_nomedia_notification_title,
                     com.android.internal.R.string.ext_media_nomedia_notification_message,
                     com.android.internal.R.drawable.stat_notify_sdcard_usb,
-                    true, false, null);
+                    true, true, null);
             updateUsbMassStorageNotification(false);
         } else if (newState.equals(Environment.MEDIA_BAD_REMOVAL)) {
             /*


### PR DESCRIPTION
Cleanly removing a USB media after unmounting leaves a permanent notification.
This fix makes it dismissable.

Change-Id: Ib6fb77f9ebfb15a60c5c29d10d3090feebc881df