### PR TITLE
Camera2 legacy: retry EGL config without EGL_RECORDABLE_ANDROID

### DIFF
--- a/core/java/android/hardware/camera2/legacy/SurfaceTextureRenderer.java
+++ b/core/java/android/hardware/camera2/legacy/SurfaceTextureRenderer.java
@@ -376,6 +376,20 @@ public class SurfaceTextureRenderer {
         EGL14.eglChooseConfig(mEGLDisplay, attribList, /*offset*/ 0, configs, /*offset*/ 0,
                 configs.length, numConfigs, /*offset*/ 0);
         checkEglError("eglCreateContext RGB888+recordable ES2");
+        if (numConfigs[0] == 0) {
+            Log.w(TAG, "eglChooseConfig returned no configs, retrying without EGL_RECORDABLE_ANDROID");
+            int[] attribList2 = {
+                    EGL14.EGL_RED_SIZE, EGL_COLOR_BITLENGTH,
+                    EGL14.EGL_GREEN_SIZE, EGL_COLOR_BITLENGTH,
+                    EGL14.EGL_BLUE_SIZE, EGL_COLOR_BITLENGTH,
+                    EGL14.EGL_RENDERABLE_TYPE, EGL14.EGL_OPENGL_ES2_BIT,
+                    EGL14.EGL_SURFACE_TYPE, EGL14.EGL_PBUFFER_BIT | EGL14.EGL_WINDOW_BIT,
+                    EGL14.EGL_NONE
+            };
+            EGL14.eglChooseConfig(mEGLDisplay, attribList2, /*offset*/ 0, configs, /*offset*/ 0,
+                    configs.length, numConfigs, /*offset*/ 0);
+            checkEglError("eglCreateContext RGB888 ES2");
+        }
         mConfigs = configs[0];
         int[] attrib_list = {
                 EGL14.EGL_CONTEXT_CLIENT_VERSION, GLES_VERSION,


### PR DESCRIPTION
Some older blobs don't support EGL_RECORDABLE_ANDROID and return no
configuration when this attribute is present. Retry eglChooseConfig
without it in this case. This fixes the flashlight for devices
affected by this and doesn't break camera-functionality.

Change-Id: Ic479231744343567233edaa1cccea7bdaafaa14f
