### PR TITLE
[1/2] base: allow stopping pinned mode for non-navbar devices

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -2645,6 +2645,12 @@ public final class Settings {
         public static final String LOCK_TO_APP_EXIT_LOCKED = "lock_to_app_exit_locked";
 
         /**
+         * Whether lock-to-app will lock the keyguard when exiting.
+         * @hide
+         */
+        public static final String LOCK_TO_APP_HIDE_DIALOG = "lock_to_app_hide_dialog";
+
+        /**
          * I am the lolrus.
          * <p>
          * Nonzero values indicate that the user has a bukkit.

--- a/core/java/com/android/internal/util/omni/DeviceUtils.java
+++ b/core/java/com/android/internal/util/omni/DeviceUtils.java
@@ -108,13 +108,14 @@ public class DeviceUtils {
         return sm.getDefaultSensor(TYPE_LIGHT) != null;
     }
 
-    /*public static boolean deviceSupportNavigationBar(Context context) {
+    public static boolean deviceSupportNavigationBar(Context context) {
         final boolean showByDefault = context.getResources().getBoolean(
                 com.android.internal.R.bool.config_showNavigationBar);
-        final int hasNavigationBar = Settings.System.getIntForUser(
+        final int hasNavigationBar = -1;
+        /*final int hasNavigationBar = Settings.System.getIntForUser(
                 context.getContentResolver(),
                 Settings.System.NAVIGATION_BAR_SHOW, -1,
-                UserHandle.USER_CURRENT);
+                UserHandle.USER_CURRENT);*/
 
         if (hasNavigationBar == -1) {
             String navBarOverride = SystemProperties.get("qemu.hw.mainkeys");
@@ -128,7 +129,7 @@ public class DeviceUtils {
         } else {
             return hasNavigationBar == 1;
         }
-    }*/
+    }
 
     private static int getScreenType(Context con) {
         WindowManager wm = (WindowManager)con.getSystemService(Context.WINDOW_SERVICE);

--- a/core/res/res/layout/lock_to_app_checkbox.xml
+++ b/core/res/res/layout/lock_to_app_checkbox.xml
@@ -17,20 +17,29 @@
 ** limitations under the License.
 */
 -->
-<FrameLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingTop="15dip"
     android:paddingBottom="0dip"
-    android:paddingStart="12dip"
+    android:paddingStart="16dip"
     android:paddingEnd="25dip"
+    android:orientation="vertical"
     >
 
     <CheckBox
         android:id="@+id/lock_to_app_checkbox"
-        style="?android:attr/textAppearanceMedium"
+        style="?android:style/TextAppearance.Material.Subhead"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:visibility="gone" />
 
-</FrameLayout>
+    <CheckBox
+        android:id="@+id/hide_lock_to_app_checkbox"
+        style="?android:style/TextAppearance.Material.Subhead"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/hide_lock_to_app_dialog" />
+
+</LinearLayout>

--- a/core/res/res/values/custom_strings.xml
+++ b/core/res/res/values/custom_strings.xml
@@ -29,4 +29,5 @@
     <!-- HW button mapping -->
     <string name="app_killed_message">App killed</string>
 
+    <string name="hide_lock_to_app_dialog">Always start</string>
 </resources>

--- a/core/res/res/values/custom_symbols.xml
+++ b/core/res/res/values/custom_symbols.xml
@@ -46,4 +46,5 @@
   <java-symbol type="bool" name="config_samsung_stk" />
 
   <java-symbol type="dimen" name="max_avatar_size" />
+  <java-symbol type="id" name="hide_lock_to_app_checkbox" />
 </resources>

--- a/services/core/java/com/android/server/am/LockTaskNotify.java
+++ b/services/core/java/com/android/server/am/LockTaskNotify.java
@@ -23,6 +23,7 @@ import android.view.accessibility.AccessibilityManager;
 import android.widget.Toast;
 
 import com.android.internal.R;
+import com.android.internal.util.omni.DeviceUtils;
 
 /**
  *  Helper to manage showing/hiding a image to notify them that they are entering
@@ -50,7 +51,8 @@ public class LockTaskNotify {
     public void handleShowToast(boolean isLocked) {
         String text = mContext.getString(isLocked
                 ? R.string.lock_to_app_toast_locked : R.string.lock_to_app_toast);
-        if (!isLocked && mAccessibilityManager.isEnabled()) {
+        boolean showSingleButtonMessage = !DeviceUtils.deviceSupportNavigationBar(mContext) || mAccessibilityManager.isEnabled();
+        if (!isLocked && showSingleButtonMessage) {
             text = mContext.getString(R.string.lock_to_app_toast_accessible);
         }
         if (mLastToast != null) {


### PR DESCRIPTION
google was so nice to ignore devices that dont have a navbar
so those have no way to leave pinned mode except rebooting :)

use long pressing recents/menu for those device to end
pinned mode to be conistent with the accessibility mode

add a "always show" checkbox to bypass the warning dialog

Change-Id: I950fdf9384e65f7cab0f0fc276f2eb25dae57a80
