### PR TITLE
SystemUI: make long pressing recent switch to last app

### DIFF
--- a/core/java/com/android/internal/util/omni/TaskUtils.java
+++ b/core/java/com/android/internal/util/omni/TaskUtils.java
@@ -18,31 +18,32 @@
 
 package com.android.internal.util.omni;
 
+import android.app.Activity;
+import android.app.ActivityOptions;
+import android.app.ActivityManager;
+import android.app.ActivityManager.RunningAppProcessInfo;
+import android.app.ActivityManagerNative;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Process;
-import android.os.UserHandle;
-import android.app.Activity;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
-import android.content.ActivityNotFoundException;
-import android.app.ActivityManager;
-import android.app.ActivityManager.RunningAppProcessInfo;
+import android.os.Process;
+import android.os.RemoteException;
+import android.os.UserHandle;
 import android.util.Log;
 
 import java.util.List;
 
 public class TaskUtils {
 
-    public static boolean killActiveTask(final Context context){
-        final Intent intent = new Intent(Intent.ACTION_MAIN);
-        String defaultHomePackage = "com.android.launcher";
-        intent.addCategory(Intent.CATEGORY_HOME);
-        final ResolveInfo res = context.getPackageManager().resolveActivity(intent, 0);
-        if (res.activityInfo != null && !res.activityInfo.packageName.equals("android")) {
-            defaultHomePackage = res.activityInfo.packageName;
-        }
+    private static final String LAUNCHER_PACKAGE = "com.android.launcher";
+    private static final String SYSTEMUI_PACKAGE = "com.android.systemui";
+
+    public static boolean killActiveTask(Context context, int userId) {
+        String defaultHomePackage = resolveCurrentLauncherPackageForUser(
+                context, userId);
         boolean targetKilled = false;
         final ActivityManager am = (ActivityManager) context
                 .getSystemService(Activity.ACTIVITY_SERVICE);
@@ -51,20 +52,21 @@ public class TaskUtils {
             int uid = appInfo.uid;
             // Make sure it's a foreground user application (not system,
             // root, phone, etc.)
-            if (uid >= Process.FIRST_APPLICATION_UID && uid <= Process.LAST_APPLICATION_UID
+            if (uid >= Process.FIRST_APPLICATION_UID
+                    && uid <= Process.LAST_APPLICATION_UID
                     && appInfo.importance == RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
                 if (appInfo.pkgList != null && (appInfo.pkgList.length > 0)) {
                     for (String pkg : appInfo.pkgList) {
-                        if (!pkg.equals("com.android.systemui")
+                        if (!pkg.equals(SYSTEMUI_PACKAGE)
                                 && !pkg.equals(defaultHomePackage)) {
-                            am.forceStopPackage(pkg);
+                            am.forceStopPackageAsUser(pkg, userId);
                             targetKilled = true;
                             break;
                         }
                     }
                 } else {
-                     Process.killProcess(appInfo.pid);
-                     targetKilled = true;
+                    Process.killProcess(appInfo.pid);
+                    targetKilled = true;
                 }
             }
             if (targetKilled) {
@@ -74,82 +76,84 @@ public class TaskUtils {
         return false;
     }
 
-    public static void toggleLastApp(final Context context){
-        final Intent intent = new Intent(Intent.ACTION_MAIN);
+    public static void toggleLastApp(Context context, int userId) {
+        String defaultHomePackage = resolveCurrentLauncherPackageForUser(
+                context, userId);
         final ActivityManager am = (ActivityManager) context
                 .getSystemService(Activity.ACTIVITY_SERVICE);
-        String defaultHomePackage = "com.android.launcher";
-        intent.addCategory(Intent.CATEGORY_HOME);
-        final ResolveInfo res = context.getPackageManager().resolveActivity(intent, 0);
-        if (res.activityInfo != null && !res.activityInfo.packageName.equals("android")) {
-            defaultHomePackage = res.activityInfo.packageName;
-        }
-        final List<ActivityManager.RecentTaskInfo> tasks =
-                am.getRecentTasks(5, ActivityManager.RECENT_IGNORE_UNAVAILABLE);
+        final List<ActivityManager.RecentTaskInfo> tasks = am
+                .getRecentTasksForUser(5,
+                        ActivityManager.RECENT_IGNORE_UNAVAILABLE, userId);
         // lets get enough tasks to find something to switch to
         // Note, we'll only get as many as the system currently has - up to 5
         int lastAppId = 0;
         Intent lastAppIntent = null;
         for (int i = 1; i < tasks.size() && lastAppIntent == null; i++) {
-            final String packageName = tasks.get(i).baseIntent.getComponent().getPackageName();
-            if (!packageName.equals(defaultHomePackage) && !packageName.equals("com.android.systemui")) {
+            final String packageName = tasks.get(i).baseIntent.getComponent()
+                    .getPackageName();
+            if (!packageName.equals(defaultHomePackage)
+                    && !packageName.equals(SYSTEMUI_PACKAGE)) {
                 final ActivityManager.RecentTaskInfo info = tasks.get(i);
                 lastAppId = info.id;
                 lastAppIntent = info.baseIntent;
             }
         }
         if (lastAppId > 0) {
-            am.moveTaskToFront(lastAppId, am.MOVE_TASK_NO_USER_ACTION);
+            final ActivityOptions opts = ActivityOptions.makeCustomAnimation(
+                    context, com.android.internal.R.anim.last_app_in,
+                    com.android.internal.R.anim.last_app_out);
+            am.moveTaskToFront(lastAppId,
+                    ActivityManager.MOVE_TASK_NO_USER_ACTION, opts.toBundle());
         } else if (lastAppIntent != null) {
             // last task is dead, restart it.
             lastAppIntent.addFlags(Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY);
             try {
                 context.startActivityAsUser(lastAppIntent, UserHandle.CURRENT);
             } catch (ActivityNotFoundException e) {
-                Log.w("Recent", "Unable to launch recent task", e);
             }
         }
     }
 
+    private static String resolveCurrentLauncherPackageForUser(Context context,
+            int userId) {
+        final Intent launcherIntent = new Intent(Intent.ACTION_MAIN)
+        .addCategory(Intent.CATEGORY_HOME);
+        final PackageManager pm = context.getPackageManager();
+        final ResolveInfo launcherInfo = pm.resolveActivityAsUser(
+                launcherIntent, 0, userId);
+        if (launcherInfo.activityInfo != null
+                && !launcherInfo.activityInfo.packageName.equals("android")) {
+            return launcherInfo.activityInfo.packageName;
+        }
+        return LAUNCHER_PACKAGE;
+    }
+
     public static int getPackagePersistentId(String packageName, Context context) {
-        Context mContext = context;
+        final ActivityManager am = (ActivityManager) context
+                .getSystemService(Context.ACTIVITY_SERVICE);
 
-        final ActivityManager am = (ActivityManager) mContext
-            .getSystemService(Context.ACTIVITY_SERVICE);
+        List<ActivityManager.RecentTaskInfo> mTasks = am.getRecentTasks(
+                Integer.MAX_VALUE, ActivityManager.RECENT_IGNORE_UNAVAILABLE);
 
-        List<ActivityManager.RecentTaskInfo> mTasks =
-            am.getRecentTasks(Integer.MAX_VALUE, ActivityManager.RECENT_IGNORE_UNAVAILABLE);
-
-        for (int i = 0; i < mTasks.size(); i++)
-        {
-            String name = mTasks.get(i).baseIntent
-                .getComponent().getPackageName();
-
-            if(name.equals(packageName)) {
+        for (int i = 0; i < mTasks.size(); i++) {
+            String name = mTasks.get(i).baseIntent.getComponent()
+                    .getPackageName();
+            if (name.equals(packageName)) {
                 return mTasks.get(i).persistentId;
             }
         }
-
         return -1;
     }
 
     public static void killPackageProcess(int mId, Context context) {
-
-        Context mContext = context;
-
-        final ActivityManager am = (ActivityManager) mContext
-            .getSystemService(Context.ACTIVITY_SERVICE);
-
+        final ActivityManager am = (ActivityManager) context
+                .getSystemService(Context.ACTIVITY_SERVICE);
         am.removeTask(mId, ActivityManager.REMOVE_TASK_KILL_PROCESS);
     }
 
     public static void movePackageToFront(int mId, Context context) {
-
-        Context mContext = context;
-
-        final ActivityManager am = (ActivityManager) mContext
-            .getSystemService(Context.ACTIVITY_SERVICE);
-
+        final ActivityManager am = (ActivityManager) context
+                .getSystemService(Context.ACTIVITY_SERVICE);
         am.moveTaskToFront(mId, ActivityManager.MOVE_TASK_WITH_HOME);
     }
 }

--- a/core/res/res/anim/last_app_in.xml
+++ b/core/res/res/anim/last_app_in.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2014 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:interpolator/linear">
+
+    <translate android:fromXDelta="0%" android:toXDelta="-35%"
+        android:zAdjustment="bottom"
+        android:duration="@android:integer/config_shortAnimTime"
+        />
+    <scale android:fromXScale="0.80" android:toXScale="1.0"
+        android:fromYScale="0.80" android:toYScale="1.0"
+        android:pivotX="50%" android:pivotY="50%"
+        android:duration="@android:integer/config_shortAnimTime"
+        />
+    <translate android:fromXDelta="-35%" android:toXDelta="35%"
+        android:zAdjustment="top"
+        android:startOffset="@android:integer/config_shortAnimTime"
+        android:duration="@android:integer/config_shortAnimTime"
+        />
+    <alpha android:fromAlpha="0.6" android:toAlpha="1.0"
+        android:duration="@android:integer/config_shortAnimTime"
+        />
+</set>

--- a/core/res/res/anim/last_app_out.xml
+++ b/core/res/res/anim/last_app_out.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2014 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:interpolator/linear">
+
+    <translate android:fromXDelta="-35%" android:toXDelta="35%"
+        android:zAdjustment="top"
+        android:duration="@android:integer/config_shortAnimTime"
+        />
+    <scale android:fromXScale="1.0" android:toXScale="0.80"
+        android:fromYScale="1.0" android:toYScale="0.80"
+        android:pivotX="50%" android:pivotY="50%"
+        android:duration="@android:integer/config_shortAnimTime"
+        />
+    <translate android:fromXDelta="35%" android:toXDelta="-35%"
+        android:zAdjustment="bottom"
+        android:startOffset="@android:integer/config_shortAnimTime"
+        android:duration="@android:integer/config_shortAnimTime"
+        />
+    <alpha android:fromAlpha="1.0" android:toAlpha="0.6"
+        android:duration="@android:integer/config_shortAnimTime"
+        />
+</set>

--- a/core/res/res/values/custom_symbols.xml
+++ b/core/res/res/values/custom_symbols.xml
@@ -47,4 +47,8 @@
 
   <java-symbol type="dimen" name="max_avatar_size" />
   <java-symbol type="id" name="hide_lock_to_app_checkbox" />
+
+  <!-- Last app switch animations -->
+  <java-symbol type="anim" name="last_app_in" />
+  <java-symbol type="anim" name="last_app_out" />
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -35,6 +35,7 @@ import android.animation.TimeInterpolator;
 import android.annotation.NonNull;
 import android.app.ActivityManager;
 import android.app.ActivityManagerNative;
+import android.app.ActivityOptions;
 import android.app.IActivityManager;
 import android.app.Notification;
 import android.app.PendingIntent;
@@ -43,6 +44,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.database.ContentObserver;
@@ -111,6 +114,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.android.internal.statusbar.StatusBarIcon;
+import com.android.internal.util.omni.TaskUtils;
 import com.android.keyguard.KeyguardHostView.OnDismissAction;
 import com.android.keyguard.ViewMediatorCallback;
 import com.android.systemui.BatteryMeterView;
@@ -3972,6 +3976,7 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
     private void handleLongPressBackRecents(View v) {
         try {
             boolean sendBackLongPress = false;
+            boolean hijackRecentsLongPress = false;
             IActivityManager activityManager = ActivityManagerNative.getDefault();
             boolean isAccessiblityEnabled = mAccessibilityManager.isEnabled();
             if (activityManager.isInLockTaskMode() && !isAccessiblityEnabled) {
@@ -3985,12 +3990,16 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
                     // If we aren't pressing recents right now then they presses
                     // won't be together, so send the standard long-press action.
                     sendBackLongPress = true;
+                } else if ((v.getId() == R.id.recent_apps) && !activityManager.isInLockTaskMode()) {
+                    hijackRecentsLongPress = true;
                 }
                 mLastLockToAppLongPress = time;
             } else {
                 // If this is back still need to handle sending the long-press event.
                 if (v.getId() == R.id.back) {
                     sendBackLongPress = true;
+                } else if ((v.getId() == R.id.recent_apps) && !activityManager.isInLockTaskMode()) {
+                    hijackRecentsLongPress = true;
                 } else if (isAccessiblityEnabled && activityManager.isInLockTaskMode()) {
                     // When in accessibility mode a long press that is recents (not back)
                     // should stop lock task.
@@ -4001,6 +4010,9 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
                 KeyButtonView keyButtonView = (KeyButtonView) v;
                 keyButtonView.sendEvent(KeyEvent.ACTION_DOWN, KeyEvent.FLAG_LONG_PRESS);
                 keyButtonView.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_LONG_CLICKED);
+            }
+            if (hijackRecentsLongPress) {
+                TaskUtils.toggleLastApp(mContext, mCurrentUserId);
             }
         } catch (RemoteException e) {
             Log.d(TAG, "Unable to reach activity manager", e);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/KeyButtonView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/KeyButtonView.java
@@ -71,6 +71,7 @@ public class KeyButtonView extends ImageView {
     private AudioManager mAudioManager;
     private Animator mAnimateToQuiescent = new ObjectAnimator();
     private KeyButtonRipple mRipple;
+    private boolean mPerformedLongClick;
 
     private final Runnable mCheckLongPress = new Runnable() {
         public void run() {
@@ -78,6 +79,7 @@ public class KeyButtonView extends ImageView {
                 // Log.d("KeyButtonView", "longpressed: " + this);
                 if (isLongClickable()) {
                     // Just an old-fashioned ImageView
+                    mPerformedLongClick = true;
                     performLongClick();
                 } else {
                     sendEvent(KeyEvent.ACTION_DOWN, KeyEvent.FLAG_LONG_PRESS);
@@ -225,13 +227,14 @@ public class KeyButtonView extends ImageView {
                     }
                 } else {
                     // no key code, just a regular ImageView
-                    if (doIt) {
+                    if (doIt && !mPerformedLongClick) {
                         performClick();
                     }
                 }
                 if (mSupportsLongpress) {
                     removeCallbacks(mCheckLongPress);
                 }
+                mPerformedLongClick = false;
                 break;
         }
 

--- a/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
+++ b/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
@@ -1158,7 +1158,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                 mBackKillPending = true;
                 break;
             case KEY_ACTION_LAST_APP:
-                TaskUtils.toggleLastApp(mContext);
+                TaskUtils.toggleLastApp(mContext, mCurrentUserId);
                 break;
             case KEY_ACTION_SLEEP:
                 mPowerManager.goToSleep(SystemClock.uptimeMillis());
@@ -3220,7 +3220,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
     Runnable mKillTask = new Runnable() {
         public void run() {
             mBackKillPending = false;
-            if (TaskUtils.killActiveTask(mContext)){
+            if (TaskUtils.killActiveTask(mContext, mCurrentUserId)){
                 performHapticFeedbackLw(null, HapticFeedbackConstants.LONG_PRESS, false);
                 Toast.makeText(mContext,
                         com.android.internal.R.string.app_killed_message, Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
ATTENTION: using the static methods from TaskUtils requires
now android.permission.INTERACT_ACROSS_USERS_FULL permission!

With this patch, long pressing the recents key on the navigation bar
will attempt to switch to your last application in the activity stack
before the active one.

The user's current home launcher package is ignored as well as SystemUI (so that
RecentsActivity does not influence the behavior).

Change-Id: I38771e0fce16b55bb5186af47115b4e812cb60b0
Signed-off-by: Roman Birg roman@cyngn.com
Signed-off-by: Adnan Begovic adnan@cyngn.com

SystemUI: unbreak accesibility longpress Overview to unpin
add a check to see if were in a locked app so not to hijack recents

allow last app action to be assigned to hardware keys
Also fix multi-user handling for 'switch to last app' and 'kill
foreground app' actions.

Change-Id: I1fb586d19b1198e6888b0f11e0a2813acf0bcd5b
Signed-off-by: Roman Birg roman@cyngn.com
Signed-off-by: Danny Baumann dannybaumann@web.de
Signed-off-by: Adnan Begovic adnan@cyngn.com

implement on top our current TaskUtils
adding a nice animation when switching apps

Change-Id: I6313903ac3c8f404c2e361446bef505eceba9117
