### PR TITLE
Systemui: Recents - do not add search widget on recents if widget is los...

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/recents/RecentsActivity.java
+++ b/packages/SystemUI/src/com/android/systemui/recents/RecentsActivity.java
@@ -287,6 +287,8 @@ public class RecentsActivity extends Activity implements RecentsView.RecentsView
                     // Save the app widget id into the settings
                     mConfig.updateSearchBarAppWidgetId(this, widgetInfo.first);
                     mSearchAppWidgetInfo = widgetInfo.second;
+                } else {
+                    mConfig.updateSearchBarAppWidgetId(this, -1);
                 }
             }
         }


### PR DESCRIPTION
...t.

We have reports that sometimes under special circumstances the widget gets lost
and the view is added nevertheless

Ensure that if the widget loading fails that the id is set back to -1 to remove
the view.

Change-Id: I62f8dcea19817a243a001c80b6a4ab7b1e31a990
